### PR TITLE
updated regex to ignore dotfiles and work with larger numbers

### DIFF
--- a/birdie.js
+++ b/birdie.js
@@ -215,7 +215,16 @@ function getMigrationById (i, files) {
   let fileName;
 
   for (let x = 0; x < files.length; x++) {
-    migrationExists = new RegExp(`${i}_`).test(files[x]);
+    var migrationId = -1;
+
+    var r = /^([0-9]+)_/;
+    var matchResult = files[x].match(r);
+
+    if(matchResult && matchResult[1]) {
+      migrationId = parseInt(matchResult[1]);
+    }
+
+    migrationExists = migrationId === i;
     if (migrationExists) {
       if (migration) {
         isDuplicated = true;


### PR DESCRIPTION
The original regex would match filenames like:

.004_foo.js

and names like the following would be counted as duplicates:

004_foo.js
040_bar.js
